### PR TITLE
fix cache errors in recursively generics

### DIFF
--- a/src/main/kotlin/com/itangcent/intellij/psi/DuckTypeHelper.kt
+++ b/src/main/kotlin/com/itangcent/intellij/psi/DuckTypeHelper.kt
@@ -5,6 +5,7 @@ import com.google.inject.Singleton
 import com.intellij.psi.*
 import com.intellij.psi.util.PsiUtil
 import com.itangcent.intellij.logger.Logger
+import com.itangcent.intellij.util.safeComputeIfAbsent
 import com.siyeh.ig.psiutils.ClassUtils
 import org.apache.commons.lang3.StringUtils
 import java.util.*
@@ -88,7 +89,7 @@ class DuckTypeHelper {
     }
 
     fun resolve(typeCanonicalText: String, context: PsiElement): DuckType? {
-        return tmTypeCanonicalTextCache.computeIfAbsent(typeCanonicalText) {
+        return tmTypeCanonicalTextCache.safeComputeIfAbsent(typeCanonicalText) {
             doResolve(typeCanonicalText, context)
         }
     }
@@ -180,7 +181,7 @@ class DuckTypeHelper {
 
     fun extractClassFromCanonicalText(typeCanonicalText: String, context: PsiElement): PsiClass? {
         val classCanonicalText = StringUtils.substringBefore(typeCanonicalText, "<")
-        return classCanonicalTextCache.computeIfAbsent(
+        return classCanonicalTextCache.safeComputeIfAbsent(
             classCanonicalText
         ) { findClass(classCanonicalText, context) }
     }
@@ -232,10 +233,10 @@ class DuckTypeHelper {
     private val qualifiedInfoCache: HashMap<PsiType, Boolean> = HashMap()
 
     fun isQualified(psiType: PsiType, context: PsiElement): Boolean {
-        return qualifiedInfoCache.computeIfAbsent(psiType) {
-            val tmType = resolve(psiType, context) ?: return@computeIfAbsent true
-            return@computeIfAbsent isQualified(tmType)
-        }
+        return qualifiedInfoCache.safeComputeIfAbsent(psiType) {
+            val tmType = resolve(psiType, context) ?: return@safeComputeIfAbsent true
+            return@safeComputeIfAbsent isQualified(tmType)
+        } ?: false
     }
 
     private fun isQualified(tmType: DuckType): Boolean {

--- a/src/main/kotlin/com/itangcent/intellij/util/MapKit.kt
+++ b/src/main/kotlin/com/itangcent/intellij/util/MapKit.kt
@@ -1,0 +1,14 @@
+package com.itangcent.intellij.util
+
+fun <K, V> MutableMap<K, V>.safeComputeIfAbsent(key: K, mappingFunction: (K) -> V): V? {
+    var mappingValue: V? = null
+    try {
+        return this.computeIfAbsent(key) {
+            mappingValue = mappingFunction(it)
+            return@computeIfAbsent mappingValue!!
+        }
+    } catch (e: ConcurrentModificationException) {
+        mappingValue?.let { this[key] = it }
+        return mappingValue
+    }
+}


### PR DESCRIPTION
Use safeComputeIfAbsent to resolve cache errors when recursively processing generics
see https://github.com/tangcent/easy-api/issues/88